### PR TITLE
Fix stale Alpine CVEs failing Trivy image scan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,9 @@ COPY --from=builder --chown=101:101 /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 RUN chmod 644 /etc/nginx/conf.d/default.conf && \
+    # Pull latest Alpine security patches - the base image digest is pinned,
+    # so upstream package fixes only land here, not by re-pulling the tag
+    apk upgrade --no-cache && \
     # Remove unnecessary packages (OWASP: Minimize Attack Surface)
     apk del apk-tools && \
     # Make root filesystem read-only where possible


### PR DESCRIPTION
## Summary
- `Containerization & Security` (secure-ci.yml) is currently failing on `master` — Trivy's `exit-code: '1'` gate catches 12 HIGH-severity, already-fixed CVEs (`c-ares`, `curl`/`libcurl`, `libcrypto3`/`libssl3`, `libexpat`, `libxml2`) inside the pinned `nginxinc/nginx-unprivileged:1.29-alpine@sha256:0c79d56a...` base image
- Root cause: the base image is pinned by digest, so Alpine's upstream package security patches never land in the built image unless pulled explicitly — nginxinc hasn't republished a patched digest for this tag yet, so bumping the pin doesn't help
- Fix: run `apk upgrade --no-cache` in the final stage before `apk del apk-tools`, so the image always picks up the latest Alpine security patches at build time regardless of base-image staleness
- Verified locally: rebuilt the image and rescanned with Trivy (`--severity CRITICAL,HIGH --ignore-unfixed`) — 12 findings before the fix, 0 after

## Test plan
- [ ] CI's `Containerization & Security` job (Trivy image scan step) passes
- [ ] Image still builds and runs correctly (unrelated to the security-patch bump, but confirming no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)