### PR TITLE
Fix GHCR push using GH_TOKS instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,10 @@
 # deploy it to Azure Container Apps.
 #
 # Every merge to master (and every v* tag) publishes a scanned, versioned
-# image to ghcr.io using the built-in GITHUB_TOKEN — no personal PAT needed.
+# image to ghcr.io using the GH_TOKS PAT secret (package-write scope).
+# The built-in GITHUB_TOKEN can't be used here: this repo's
+# default_workflow_permissions is set to read-only, which caps GITHUB_TOKEN
+# regardless of the packages: write declared below.
 #
 # Tags published:
 #   latest      - on pushes to master
@@ -88,7 +91,10 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          # GITHUB_TOKEN's write:packages grant is capped by the repo's
+          # default_workflow_permissions setting (currently read-only), so
+          # use the existing PAT that already has package-write instead.
+          password: ${{ secrets.GH_TOKS }}
 
       - name: Extract image metadata
         id: meta


### PR DESCRIPTION
## Summary
- Every `Release` workflow run has failed at the "Push image to GHCR" step since it was introduced (`02498f5`, going back to PR #11) — `denied: permission_denied: write_package`
- Root cause: this repo's Settings → Actions → "default_workflow_permissions" is set to read-only, which caps the auto-generated `GITHUB_TOKEN`'s effective grant regardless of the `packages: write` declared in the `build-publish` job — the workflow-level permission can't raise it above that repo ceiling
- Rather than widening that repo-wide setting (which would raise the default token ceiling for every workflow), this uses the existing `GH_TOKS` PAT secret (already has package-write scope, already used elsewhere in this repo's CI) for the `docker/login-action` step instead
- Updated the workflow's header comment, which incorrectly claimed "no personal PAT needed"

## Test plan
- [ ] `Release` workflow's `build-publish` job succeeds through the GHCR login + push steps
- [ ] Confirm the pushed `sha-<short>`/`latest` tags actually appear on `ghcr.io/ameerfaisaladanan/formatje`
- [ ] Once merged, confirm `deploy-azure` (added in #28) picks up the newly-pushed image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)