### PR TITLE
Fix Gitleaks failing on Dependabot PRs (use GITHUB_TOKEN, not GH_TOKS)

### DIFF
--- a/.github/workflows/secure-ci.yml
+++ b/.github/workflows/secure-ci.yml
@@ -160,4 +160,8 @@ jobs:
       - name: Run Gitleaks
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKS }}
+          # Dependabot-triggered runs don't get access to custom repo
+          # secrets (GH_TOKS resolves empty there), but GITHUB_TOKEN is
+          # always provided regardless of trigger - gitleaks only needs
+          # read access to fetch the PR's commit range.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Every open Dependabot PR was failing "Secret Scanning" with: `GITHUB_TOKEN is now required to scan pull requests`
- Root cause: GitHub restricts custom repo secrets from workflow runs triggered by Dependabot (a safeguard against a malicious dependency bump exfiltrating secrets) — `secrets.GH_TOKS` resolves to an empty string on those runs specifically, which is what gitleaks-action needs to fetch the PR's commit range for `pull_request` events
- Confirmed isolated to this one job: on PR #13 (a clean GH-Action-only bump), every other check passes — CodeQL, Trivy, Semgrep, Containerization & Security, Quality & Linting — only Secret Scanning fails
- Fix: use the automatically-provided `secrets.GITHUB_TOKEN` instead, which is always present regardless of trigger. It only needs read access, already covered by the job's existing `permissions: contents: read`

## Test plan
- [ ] Re-run Secret Scanning on any open Dependabot PR (e.g. #13, #16, #17) and confirm it passes
- [ ] Confirm Secret Scanning still passes on normal (non-Dependabot) PRs and pushes to master

🤖 Generated with [Claude Code](https://claude.com/claude-code)