### PR TITLE
Stop secure-ci.yml duplicating checks on master push

### DIFF
--- a/.github/workflows/secure-ci.yml
+++ b/.github/workflows/secure-ci.yml
@@ -2,8 +2,11 @@
 #
 # Enforces quality, security, and supply chain integrity for the app.
 #
-# Triggers: pull requests targeting master and pushes to master, so the
-# branch that ships is always covered.
+# Triggers: pull requests targeting master only - this is the pre-merge
+# gate. It deliberately does NOT also run on push to master: release.yml
+# owns that path (its own verify job re-runs lint/test/build, and its
+# own Trivy step re-scans the image before publish/deploy), so running
+# this workflow again on the same push would just duplicate that work.
 # Jobs:
 #   1. Quality & Linting (eslint, prettier, vitest, build)
 #   2. Containerization & Security (Trivy, CodeQL, Hadolint)
@@ -16,9 +19,6 @@
 name: Secure CI Pipeline
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master


### PR DESCRIPTION
## Summary
- `secure-ci.yml` was triggered on both `pull_request` and `push: branches: [master]` — every merge to master re-ran the entire lint/test/build/CodeQL/Trivy/Semgrep/Gitleaks suite a second time, right after it had already run (and gated the merge) as a PR check
- `release.yml` already owns the post-merge path on the same `push: branches: [master]` trigger: its `verify` job independently re-runs lint/test/build, and `build-publish` independently re-scans the built image with Trivy before publish/deploy
- Removed the `push` trigger from `secure-ci.yml`, leaving it `pull_request`-only — it's now purely the pre-merge gate, no duplicate work on merge

## Trade-off worth knowing
CodeQL/Semgrep results in the GitHub Security tab were previously refreshed on every master push too; now they only update when a PR is open against master. Since branch protection requires all changes to go through a reviewed PR anyway, what lands on master was already scanned in that PR - so this shouldn't lose real signal, just the redundant re-scan. Flagging in case you want a lightweight scheduled re-scan of master added back later for the Security tab baseline.

## Test plan
- [ ] Confirm `secure-ci.yml` still runs and gates new PRs
- [ ] Confirm a merge to master no longer triggers a second `secure-ci.yml` run (only `release.yml` should fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)