### PR TITLE
Validate URL format in JSON-to-cURL converter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,7 @@ export default [
         navigator: "readonly",
         setTimeout: "readonly",
         clearTimeout: "readonly",
+        URL: "readonly",
         JSX: true,
       },
     },

--- a/src/utils/__tests__/curlConverter.test.js
+++ b/src/utils/__tests__/curlConverter.test.js
@@ -80,6 +80,12 @@ describe("convertJsonToCurl", () => {
     );
   });
 
+  it("rejects a malformed url", () => {
+    expect(() =>
+      convertJsonToCurl(JSON.stringify({ url: "not a url" }))
+    ).toThrow(/Invalid URL/);
+  });
+
   it("rejects array headers", () => {
     expect(() =>
       convertJsonToCurl(

--- a/src/utils/curlConverter.js
+++ b/src/utils/curlConverter.js
@@ -21,6 +21,19 @@ const escapeShellArg = (str) => {
 };
 
 /**
+ * Validates a URL string using the URL API
+ * @param {string} urlString - The URL to validate
+ * @throws {Error} If the URL is malformed
+ */
+const validateUrl = (urlString) => {
+  try {
+    new URL(urlString);
+  } catch (e) {
+    throw new Error(`Invalid URL: ${e.message}`);
+  }
+};
+
+/**
  * Validates the input JSON structure
  * @param {any} data - The data to validate
  * @throws {Error} If validation fails
@@ -33,6 +46,8 @@ const validateRequestData = (data) => {
   if (!data.url || typeof data.url !== "string") {
     throw new Error("URL is required and must be a string");
   }
+
+  validateUrl(data.url);
 
   if (data.method && typeof data.method !== "string") {
     throw new Error("Method must be a string");


### PR DESCRIPTION
## Summary
Extracted from the stale PR #10 (which is being closed as superseded - its dependency-bump portion is obsolete). This is the one still-relevant piece: reject malformed URLs early in `curlConverter.js` with a clear error, instead of letting bad input flow silently into curl-command generation.

## Correction to the original framing
PR #10 described this as SSRF prevention. That's not accurate for this app: it's 100% client-side (per the README - no server executes requests based on this input, it just generates a `curl` string for the user to copy). There's no SSRF vector here to prevent. This is plain input validation / better error messaging, not a security fix - framing it accurately here.

## Changes
- `src/utils/curlConverter.js`: added `validateUrl()` using the `URL` constructor, called from `validateRequestData()`
- `eslint.config.js`: added missing `URL` global (caused a `no-undef` lint error without it)
- `src/utils/__tests__/curlConverter.test.js`: added a test for the malformed-URL rejection case

## Test plan
- [x] `npm run lint` - clean
- [x] `npm test` - 28/28 passing (27 existing + 1 new)
- [x] `npm run build` - succeeds
- [x] Confirmed all existing test fixtures use well-formed absolute URLs, so this doesn't break anything already passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)